### PR TITLE
Fix wrong link in top10 markdown file

### DIFF
--- a/2023/ML04_2023-Membership_Inference_Attack.md
+++ b/2023/ML04_2023-Membership_Inference_Attack.md
@@ -31,7 +31,7 @@ specific circumstances of each machine learning system.
 
 **Description:**
 
-Membership interference attacks occur when an attacker manipulates the
+Membership inference attacks occur when an attacker manipulates the
 model's training data in order to cause it to behave in a way that
 exposes sensitive information.
 

--- a/2023/Top_10.md
+++ b/2023/Top_10.md
@@ -14,7 +14,7 @@ redirect_from:
 [ML01:2023 Adversarial Attack](ML01_2023-Adversarial_Attack.md)  
 [ML02:2023 Data Poisoning Attack](ML02_2023-Data_Poisoning_Attack.md)  
 [ML03:2023 Model Inversion Attack](ML03_2023-Model_Inversion_Attack.md)  
-[ML04:2023 Membership Interference Attack](ML04_2023-Membership_interference_Attack.md)  
+[ML04:2023 Membership Inference Attack](ML04_2023-Membership_Inference_Attack.md)
 [ML05:2023 Model Stealing](ML05_2023-Model_Stealing.md)  
 [ML06:2023 Corrupted Packages](ML06_2023-Corrupted_Packages.md)  
 [ML07:2023 Transfer Learning Attack](ML07_2023-Transfer_Learning_Attack.md)  

--- a/2023/Top_10.md
+++ b/2023/Top_10.md
@@ -14,7 +14,7 @@ redirect_from:
 [ML01:2023 Adversarial Attack](ML01_2023-Adversarial_Attack.md)  
 [ML02:2023 Data Poisoning Attack](ML02_2023-Data_Poisoning_Attack.md)  
 [ML03:2023 Model Inversion Attack](ML03_2023-Model_Inversion_Attack.md)  
-[ML04:2023 Membership Inference Attack](ML04_2023-Membership_Inference_Attack.md)
+[ML04:2023 Membership Inference Attack](ML04_2023-Membership_Inference_Attack.md)  
 [ML05:2023 Model Stealing](ML05_2023-Model_Stealing.md)  
 [ML06:2023 Corrupted Packages](ML06_2023-Corrupted_Packages.md)  
 [ML07:2023 Transfer Learning Attack](ML07_2023-Transfer_Learning_Attack.md)  


### PR DESCRIPTION
The current link in the top10 file for the Membership Inference Attack redirects to `ML04_2023-Membership_interference_Attack.md`, but the file is (correctly) named `2023/ML04_2023-Membership_Inference_Attack.md`