### PR TITLE
Issue #29: Create a RELATED.md to list similar projects and SIGs

### DIFF
--- a/RELATED.md
+++ b/RELATED.md
@@ -1,0 +1,12 @@
+# Related projects
+
+This lists contains projects related/similar to OWASP Top10 for Machine Learning. 
+
+1. [MLSecOps Top10](https://ethical.institute/security.html)
+2. [OWASP Top10 for Large Language Models](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+3. [AI Vulnerability Database (AVID)](https://avidml.org/)
+4. [MITRE ATLAS](https://atlas.mitre.org/)
+5. [AI Risk Database](https://airisk.io/)
+6. [OWASP AI Security and Privacy Guide](https://owasp.org/www-project-ai-security-and-privacy-guide/)
+7. [ETSI "Securing Artificial Intelligence](https://www.etsi.org/technologies/securing-artificial-intelligence)
+8. [Linux Foundation AI&Data ML Security Comittee](https://lfaidata.foundation/projects/ml-security-committee/)

--- a/leaders.md
+++ b/leaders.md
@@ -1,11 +1,12 @@
 ### Leaders
-* [Abraham Kang](mailto:abraham.kang@owasp.org)
-* [Shain Singh](mailto:shain.singh@owasp.org)
-* [Sagar Bhure](mailto:sagar.bhure@owasp.org)
-* [Rob van der Veer](mailto:rob.vanderveer@owasp.org)
+- [Abraham Kang](mailto:abraham.kang@owasp.org)
+- [Shain Singh](mailto:shain.singh@owasp.org)
+- [Sagar Bhure](mailto:sagar.bhure@owasp.org)
+- [Rob van der Veer](mailto:rob.vanderveer@owasp.org)
 
 
 ### Contributors
+
 - [Vamsi Suman Kanukollu](mailto:sumankanukollu@gmail.com)
 - [M S Nishanth](mailto:msnishanth9001@gmail.com)
 - [Buchibabu Bandarupally](mailto:buchibabu.bandarupally@gmail.com)

--- a/leaders.md
+++ b/leaders.md
@@ -15,4 +15,3 @@
 - [Jakub Kaluzny](mailto:jakub.artur.kaluzny@gmail.com)
 - [David Ottenheimer](mailto:david@inrupt.com)
 - [Haral Tsitsivas](mailto:haral.tsitsivas@owasp.org)
-

--- a/leaders.md
+++ b/leaders.md
@@ -1,9 +1,9 @@
 ### Leaders
+
 - [Abraham Kang](mailto:abraham.kang@owasp.org)
 - [Shain Singh](mailto:shain.singh@owasp.org)
 - [Sagar Bhure](mailto:sagar.bhure@owasp.org)
 - [Rob van der Veer](mailto:rob.vanderveer@owasp.org)
-
 
 ### Contributors
 
@@ -15,3 +15,4 @@
 - [Jakub Kaluzny](mailto:jakub.artur.kaluzny@gmail.com)
 - [David Ottenheimer](mailto:david@inrupt.com)
 - [Haral Tsitsivas](mailto:haral.tsitsivas@owasp.org)
+


### PR DESCRIPTION
Hello, I've created a list of projects and SIGs similar to OWASP Top10 for ML Security. I don't know what is a suggested format, but I think I've included the most renowned resources regarding AI/ML security. 

Related issue: https://github.com/OWASP/www-project-machine-learning-security-top-10/issues/29